### PR TITLE
Add Back to Top button

### DIFF
--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,0 +1,34 @@
+import React, { useState, useEffect } from "react";
+import "../styles/ScrollToTop.css";
+
+const ScrollToTop = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const toggleVisibility = () => {
+    setIsVisible(window.scrollY > 200);
+  };
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
+
+  useEffect(() => {
+    window.addEventListener("scroll", toggleVisibility);
+    return () => window.removeEventListener("scroll", toggleVisibility);
+  }, []);
+
+  return (
+    <button
+      className={`scroll-to-top ${isVisible ? "show" : ""}`}
+      onClick={scrollToTop}
+      aria-label="Back to top"
+    >
+      ↑
+    </button>
+  );
+};
+
+export default ScrollToTop;

--- a/src/styles/ScrollToTop.css
+++ b/src/styles/ScrollToTop.css
@@ -1,0 +1,27 @@
+.scroll-to-top {
+  position: fixed;
+  bottom: 40px;
+  right: 40px;
+  background-color: #333;
+  color: white;
+  border: none;
+  border-radius: 50%;
+  padding: 12px 18px;
+  font-size: 20px;
+  cursor: pointer;
+  box-shadow: 0 4px 6px rgba(0,0,0,0.3);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.4s ease-in-out;
+  z-index: 1000;
+}
+
+.scroll-to-top.show {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.scroll-to-top:hover {
+  background-color: #555;
+}
+


### PR DESCRIPTION
Done Creating a floating button that appears when the user scrolls down 200px. On click, it smoothly scrolls the page back to the top.
with a hover effect  and smooth transition of fade when scrolling

The button is styled (e.g., round with an ↑ icon).
Only visible when user scrolls past a 200px.
uses Smooth scroll effect (use window.scrollTo with { behavior: "smooth" }).

Files edited:
src/components/ScrollToTop.jsx
src/styles/ScrollToTop.css

it is in the right bottom corner -
<img width="232" height="184" alt="image" src="https://github.com/user-attachments/assets/deaec9fc-72c7-4a11-b142-99dc9c8a4134" />

Closes #48 

