### PR TITLE
feat: Implement responsive navbar with hamburger menu on mobile 

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import '../styles/Navbar.css';
+
+const Navbar = ({ links }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleMenu = () => {
+    setIsOpen(prev => !prev);
+  };
+
+  const handleLinkClick = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <nav className="navbar">
+      <div className="navbar-inner">
+        <div className="navbar-brand">
+          <span className="logo">MySite</span>
+          <button
+            className="hamburger"
+            onClick={toggleMenu}
+            aria-label="Toggle navigation menu"
+            aria-expanded={isOpen}
+          >
+            <span className="hamburger-line" />
+            <span className="hamburger-line" />
+            <span className="hamburger-line" />
+          </button>
+        </div>
+
+        <ul className={`navbar-links ${isOpen ? 'open' : ''}`}>
+          {links.map((link, index) => (
+            <li key={index} className="navbar-item">
+              <a href={link.href} onClick={handleLinkClick}>
+                {link.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </nav>
+  );
+};
+
+export default Navbar;

--- a/src/styles/Navbar.css
+++ b/src/styles/Navbar.css
@@ -1,0 +1,84 @@
+/* Base styles */
+.navbar {
+  background-color: #6e6ef2;
+  color: white;
+  padding: 1rem;
+}
+
+/* Flex container */
+.navbar-brand {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.navbar-inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+/* Logo */
+.logo {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-right: 2rem;
+}
+
+/* Hamburger icon */
+.hamburger {
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: none;
+  flex-direction: column;
+  gap: 4px;
+  margin-left: auto;
+}
+
+.hamburger-line {
+  width: 25px;
+  height: 3px;
+  background-color: white;
+  display: block;
+}
+
+/* Links */
+.navbar-links {
+  display: flex;
+  list-style: none;
+  gap: 1rem;
+}
+
+.navbar-item a {
+  color: white;
+  text-decoration: none;
+}
+
+.navbar-item a:hover {
+  text-decoration: underline;
+}
+
+/* Mobile styles */
+@media (max-width: 768px) {
+  .navbar-inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .hamburger {
+    display: flex;
+  }
+
+  .navbar-links {
+    display: none;
+    flex-direction: column;
+    width: 100%;
+    margin-top: 1rem;
+  }
+
+  .navbar-links.open {
+    display: flex;
+  }
+}


### PR DESCRIPTION
This PR adds a responsive, reusable Navbar component that collapses into a hamburger menu on mobile screens. On larger screens, the navigation links appear next to the logo, while on smaller devices, the links toggle visibility via a hamburger icon aligned to the far right. The implementation meets accessibility standards and fulfills the issue requirements.
<img width="1897" height="120" alt="image" src="https://github.com/user-attachments/assets/b39cc367-1dff-4576-ac42-00dbc01e6ae7" />
<img width="229" height="241" alt="image" src="https://github.com/user-attachments/assets/2c6951e7-89fe-46f0-a3cd-cfd86ae13c0a" />
<img width="212" height="98" alt="image" src="https://github.com/user-attachments/assets/2676d8e2-ef6c-4fae-ad85-5b2e4742d741" />
<img width="918" height="89" alt="image" src="https://github.com/user-attachments/assets/9db64890-c078-4c69-a8cd-b41a3d7149cb" />

Closes #63
