### PR TITLE
feat: add creation day info to todo items

### DIFF
--- a/app.js
+++ b/app.js
@@ -133,6 +133,8 @@ function addTodo(e) {
 
   const d = new Date();
   const createTime = d.getTime();
+  const dayNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+  const day = dayNames[d.getDay()];
   const infoText = `The todo item was created at ${createTime}, ${day}`;
   const currentValue = htmlEncode(todoInput.value)?.trim() || "";
   const categoryValue = document.getElementById("categorySelect").value;


### PR DESCRIPTION


- Added day of the week along with timestamp for each todo.
- Stored this info in `infoText` to show when the task was created.
- Improves clarity for users about creation time.
- Enhanced Todo App by including the day of the week in task creation metadata, providing users with more contextual information about when tasks were added.
