### PR TITLE
Build a reusable, accessible modal component (#70)

### DIFF
--- a/modal_component/modal.html
+++ b/modal_component/modal.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Accessible Modal</title>
+</head>
+<body style="font-family: Arial, sans-serif;">
+
+  
+  <button id="openModalBtn" style="padding:10px 20px; cursor:pointer;">
+    Open Modal
+  </button>
+
+  
+  <div id="modalOverlay" 
+       style="position:fixed; inset:0; background:rgba(0,0,0,0.6); display:none; align-items:center; justify-content:center; z-index:999;"
+       aria-hidden="true">
+
+    
+    <div id="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle" tabindex="-1"
+         style="background:#fff; border-radius:10px; padding:20px; width:400px; max-width:90%; box-shadow:0 5px 20px rgba(0,0,0,0.3);">
+      
+      <h2 id="modalTitle" style="margin-top:0;">Example Modal</h2>
+      <p>This is a simple accessible modal example.</p>
+      <input type="text" placeholder="Type something..." style="width:100%; padding:8px; margin-top:8px;">
+      <button id="closeModalBtn" style="margin-top:12px; padding:8px 16px; cursor:pointer;">Close</button>
+    </div>
+  </div>
+
+  
+  <script src="modal.js"></script>
+</body>
+</html>

--- a/modal_component/modal.js
+++ b/modal_component/modal.js
@@ -1,0 +1,72 @@
+const openBtn = document.getElementById("openModalBtn");
+const modalOverlay = document.getElementById("modalOverlay");
+const modal = document.getElementById("modal");
+const closeBtn = document.getElementById("closeModalBtn");
+let lastFocusedElement = null;
+
+
+function getFocusableElements(container) {
+  return Array.from(container.querySelectorAll(
+    'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+  ));
+}
+
+function openModal() {
+  lastFocusedElement = document.activeElement;
+  modalOverlay.style.display = "flex";
+  modalOverlay.setAttribute("aria-hidden", "false");
+  document.body.style.overflow = "hidden";
+
+  const focusables = getFocusableElements(modal);
+  if (focusables.length) focusables[0].focus();
+  else modal.focus();
+}
+
+
+function closeModal() {
+  modalOverlay.style.display = "none";
+  modalOverlay.setAttribute("aria-hidden", "true");
+  document.body.style.overflow = "";
+  if (lastFocusedElement) lastFocusedElement.focus();
+}
+
+
+openBtn.addEventListener("click", openModal);
+closeBtn.addEventListener("click", closeModal);
+modalOverlay.addEventListener("click", (e) => {
+  if (e.target === modalOverlay) closeModal();
+});
+
+
+window.addEventListener("keydown", (e) => {
+  if (modalOverlay.style.display !== "flex") return;
+
+  
+  if (e.key === "Escape") {
+    closeModal();
+  }
+
+  
+  if (e.key === "Tab") {
+    const focusables = getFocusableElements(modal);
+    if (!focusables.length) {
+      e.preventDefault();
+      return;
+    }
+
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+
+    if (e.shiftKey) {
+      if (document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else {
+      if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Description
Added a reusable, accessible modal component built with vanilla JavaScript.

### Features
- Opens via button click.
- Focus automatically moves into the modal.
- Focus is trapped inside while modal is open.
- Closes via **Esc** key or clicking the overlay.
- Returns focus to the opener on close.

### Accessibility
- Keyboard navigable.
- Focus trap implemented.
- Screen-reader friendly labels can be added.

### Issue Reference
Fixes #70

### Screenshot
![Modal Screenshot](https://github.com/user-attachments/assets/2b75a5c0-d7ae-446f-a6ef-65a58e67d4bb)