### PR TITLE
Reverse Nodes in K-Group | Linked List Manipulation using Recursion & Pointers

### DIFF
--- a/reversenodeKGroup.java
+++ b/reversenodeKGroup.java
@@ -1,0 +1,35 @@
+class Solution {
+    public ListNode reverseKGroup(ListNode head, int k) {
+        ListNode curr = head;
+        int count = 0;
+        while (curr != null) {
+            count++;
+            curr = curr.next;
+        }
+        ListNode dummy = new ListNode(0);
+        dummy.next = head;
+        ListNode prevGroupTail = dummy;
+        curr = head;
+        while (count >= k) {
+            ListNode newHead = reverseKNodes(curr, k);
+            prevGroupTail.next = newHead;
+            prevGroupTail = curr;
+            curr = curr.next;
+            count -= k;
+        }
+        return dummy.next;
+    }
+
+    private ListNode reverseKNodes(ListNode head, int k) {
+        ListNode prev = null, curr = head;
+        while (k > 0) {
+            ListNode next = curr.next;
+            curr.next = prev;
+            prev = curr;
+            curr = next;
+            k--;
+        }
+        head.next = curr;
+        return prev;
+    }
+}


### PR DESCRIPTION
The Reverse Nodes in K-Group problem is an advanced linked list manipulation challenge that tests your understanding of pointer operations, recursion, and group-based reversal.

Given the head of a linked list, the task is to reverse the nodes of the list in groups of size k and return the modified list.
If the number of nodes is not a multiple of k, the remaining nodes at the end should remain in their original order.

This problem is an excellent demonstration of how to manage node references, recursive calls, and edge cases in linked list operations.

-> Key Concepts

1. Linked List Traversal

2. Group-wise Reversal

3. Pointer Manipulation

4. Recursion and Iteration

5. Time Complexity: O(n)

6. Space Complexity: O(1) (ignoring recursion stack)

-> Example

Input:

head = [1, 2, 3, 4, 5], k = 2


Output:

[2, 1, 4, 3, 5]


Explanation:
Nodes are reversed in groups of size 2. The last node remains unchanged as it does not form a complete group.

Input:

head = [1, 2, 3, 4, 5], k = 3


Output:

[3, 2, 1, 4, 5]


Explanation:
The first three nodes are reversed, while the remaining two stay in original order.

-> Algorithm Overview

1. Count the total nodes in the current segment.

2. If fewer than k nodes remain, stop reversing and return the current head.

3. Reverse the first k nodes using pointer manipulation.

4. Recursively call the function for the remaining list.

5. Connect the reversed portion to the result of the recursive call.