### PR TITLE
Remove Redundant vertical-align from block elements

### DIFF
--- a/calculator/output.css
+++ b/calculator/output.css
@@ -98,7 +98,6 @@
   }
   img, svg, video, canvas, audio, iframe, embed, object {
     display: block;
-    vertical-align: middle;
   }
   img, video {
     max-width: 100%;


### PR DESCRIPTION
Removed `vertical-align: middle` from elements that are explicitly set to `display: block`

`vertical-align` does not affect block-level elements in normal flow, so the declaration was redundant. This change simplifies the stylesheet without changing behaviour