### PR TITLE
Fix bug in hi.py escape sequence, fix typos in C++ code, update .gitignore, add CODE_OF_CONDUCT.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/
+node_modules/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,114 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that are constructive, welcoming,
+helpful, and beneficial to the community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies
+when an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**vipin.maurya.er@gmail.com**.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited
+interaction with those enforcing the Code of Conduct, is permitted during this
+period. Violating further terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited
+interaction with those enforcing the Code of Conduct, is permitted during this
+period. Violating further terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of harassment or discrimination,
+or other conduct that is clearly outside the bounds of acceptable behavior.
+
+**Consequence**: A permanent ban from any public participation in the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/deadlock_in_threads.cpp.cpp
+++ b/deadlock_in_threads.cpp.cpp
@@ -6,14 +6,14 @@ std::mutex mutex1;
 std::mutex mutex2;
 
 void thread1() {
-    std::cout<<"Thread 1 starst";
+    std::cout<<"Thread 1 starts\n";
     std::lock_guard<std::mutex> lock1(mutex1);
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     std::lock_guard<std::mutex> lock2(mutex2); // Potential deadlock
 }
 
 void thread2() {
-    std::cout<<"Thread 2 starst";
+    std::cout<<"Thread 2 starts\n";
     std::lock_guard<std::mutex> lock2(mutex2);
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     std::lock_guard<std::mutex> lock1(mutex1); // Potential deadlock

--- a/hi.py
+++ b/hi.py
@@ -16,7 +16,7 @@ translated_text = translator.translate(text_to_translate)
 print(f"Original text: {text_to_translate}")
 print(f"Translated text (English): {translated_text}")
 
-print("/n--Additional Examples ---")
+print("\n--Additional Examples ---")
 
 text_english = "Hello brother, how are you?"
 


### PR DESCRIPTION
## Summary of Changes

This PR includes the following improvements:

1. **hi.py**: Fixed a bug where `/n` was used instead of `\n` in a `print()` statement (line 19). The forward slash was being printed literally instead of creating a newline.

2. **deadlock_in_threads.cpp.cpp**: Fixed typos in output messages - changed `starst` to `starts` in both `thread1()` and `thread2()` functions.

3. **.gitignore**: Added `node_modules/` to prevent committing Node.js dependencies (the repo currently has a `node_modules/` directory tracked in git).

4. **CODE_OF_CONDUCT.md**: Added a new Code of Conduct file based on Contributor Covenant v2.0. The README.md already referenced a Code of Conduct, but no such file existed in the repository.

These changes improve code correctness, repository hygiene, and community documentation.